### PR TITLE
modify metaclass syntax to support python2.7

### DIFF
--- a/block/block.py
+++ b/block/block.py
@@ -91,7 +91,8 @@ def _get_backend(rows, dtype, arrtype):
     assert(False)
 
 
-class Backend(metaclass=ABCMeta):
+class Backend():
+    __metaclass__=ABCMeta
 
     @abstractmethod
     def extract_shape(self, x): pass


### PR DESCRIPTION
just modified one line code of  metaclass syntax to support python2.7 . and it pass test
