### PR TITLE
Fix numpy version in `setup.py`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,6 @@ setup(
     url='https://github.com/bamos/block',
     packages=find_packages(),
     install_requires=[
-        'numpy>=1<2',
+        'numpy>=1,<2',
     ]
 )


### PR DESCRIPTION
There is a typo in `setup.py` when specifying the `numpy` version. This makes `pip install block` fail.